### PR TITLE
Fixes issue "No module named 'ComfyUI_SimpleTiles' #13"

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1,5 +1,5 @@
-from ComfyUI_SimpleTiles.standard import TileSplit, TileMerge, TileCalc
-from ComfyUI_SimpleTiles.dynamic import DynamicTileSplit, DynamicTileMerge
+from .standard import TileSplit, TileMerge, TileCalc
+from .dynamic import DynamicTileSplit, DynamicTileMerge
 
 NODE_CLASS_MAPPINGS = {
     "TileSplit": TileSplit,


### PR DESCRIPTION
The fix is to change those lines in nodes.py:

# Before
from ComfyUI_SimpleTiles.standard import TileSplit, TileMerge, TileCalc
from ComfyUI_SimpleTiles.dynamic import DynamicTileSplit, DynamicTileMerge

# After
from .standard import TileSplit, TileMerge, TileCalc
from .dynamic import DynamicTileSplit, DynamicTileMerge